### PR TITLE
Fix value from controlled component not being set when it is zero

### DIFF
--- a/lib/elements/slider.js
+++ b/lib/elements/slider.js
@@ -30,7 +30,8 @@ export default class Slider extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.value && nextProps.value !== this.state.value) {
+    const isValueUnset = nextProps.value == null;
+    if (!isValueUnset && nextProps.value !== this.state.value) {
       if (this.props.multiple) {
         const different = this.isDifferentArrays(
           nextProps.value,


### PR DESCRIPTION
I've changed the `componentWillReceiveProps` allow 0 to be set as the a value from outside the component.

I think the expected behavior would be to just not let `null` or `undefined` to be set, is that alright?